### PR TITLE
Adiciona filtro de situação em relatórios

### DIFF
--- a/frontend/src/app/components/pages/admin/pagina-relatorio-receitas-categoria/pagina-relatorio-receitas-categoria.component.html
+++ b/frontend/src/app/components/pages/admin/pagina-relatorio-receitas-categoria/pagina-relatorio-receitas-categoria.component.html
@@ -11,8 +11,9 @@
       </h2>
     </div>
 
-    <!-- Botão Gerar PDF -->
-    <div class="mb-6">
+    <!-- Filtros e Botão Gerar PDF -->
+    <div class="mb-6 flex items-end gap-4">
+      <app-multi-select-estado (estadosChange)="estadosSelecionados = $event"></app-multi-select-estado>
       <button
         (click)="gerarPDF()"
         [disabled]="!resultados.length"

--- a/frontend/src/app/components/pages/admin/pagina-relatorio-receitas-categoria/pagina-relatorio-receitas-categoria.component.ts
+++ b/frontend/src/app/components/pages/admin/pagina-relatorio-receitas-categoria/pagina-relatorio-receitas-categoria.component.ts
@@ -6,29 +6,34 @@ import { Component, OnInit } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 
 import { ReceitaPorCategoria, ReportService } from '../../../../services/report.service';
+import { Situacao } from '../../../../shared/models/solicitacao.model';
+import { MultiSelectEstadoComponent } from '../../../ui/multi-select-estado/multi-select-estado.component';
 import { MensagemComponent } from '../../../ui/mensagem/mensagem.component';
 import { SidebarFuncionarioComponent } from '../../../ui/sidebar-funcionario/sidebar-funcionario.component';
 
 @Component({
 	selector: 'app-pagina-relatorio-receitas-categoria',
 	standalone: true,
-	imports: [CommonModule, RouterOutlet, SidebarFuncionarioComponent, MensagemComponent],
+        imports: [CommonModule, RouterOutlet, SidebarFuncionarioComponent, MensagemComponent, MultiSelectEstadoComponent],
 	templateUrl: './pagina-relatorio-receitas-categoria.component.html',
 	styleUrls: ['./pagina-relatorio-receitas-categoria.component.css'],
 })
 export class PaginaRelatorioReceitasCategoriaComponent implements OnInit {
-	resultados: ReceitaPorCategoria[] = [];
-	mensagem = '';
-	showMessage = false;
+        resultados: ReceitaPorCategoria[] = [];
+        mensagem = '';
+        showMessage = false;
+        estadosSelecionados: Situacao[] = [Situacao.FINALIZADA];
 
 	constructor(private reportService: ReportService) {}
 
-	ngOnInit(): void {
-		// já carrega os dados ao entrar na página
-		this.reportService.getReceitaPorCategoria().subscribe((resultados) => {
-			this.resultados = resultados;
-		});
-	}
+        ngOnInit(): void {
+                // já carrega os dados ao entrar na página
+                this.reportService
+                        .getReceitaPorCategoria(this.estadosSelecionados)
+                        .subscribe((resultados) => {
+                        this.resultados = resultados;
+                });
+        }
 
 	gerarPDF(): void {
 		if (!this.resultados.length) {

--- a/frontend/src/app/components/pages/admin/pagina-relatorio-receitas/pagina-relatorio-receitas.component.html
+++ b/frontend/src/app/components/pages/admin/pagina-relatorio-receitas/pagina-relatorio-receitas.component.html
@@ -37,6 +37,7 @@
             class="px-3 py-2 rounded-md border border-gray-300 focus:outline-primary"
           />
         </div>
+        <app-multi-select-estado (estadosChange)="estadosSelecionados = $event"></app-multi-select-estado>
       </div>
       <div class="flex gap-3">
         <button

--- a/frontend/src/app/components/pages/admin/pagina-relatorio-receitas/pagina-relatorio-receitas.component.ts
+++ b/frontend/src/app/components/pages/admin/pagina-relatorio-receitas/pagina-relatorio-receitas.component.ts
@@ -7,32 +7,37 @@ import { FormsModule } from '@angular/forms';
 import { RouterOutlet } from '@angular/router';
 
 import { ReceitaPorDia, ReportService } from '../../../../services/report.service';
+import { Situacao } from '../../../../shared/models/solicitacao.model';
+import { MultiSelectEstadoComponent } from '../../../ui/multi-select-estado/multi-select-estado.component';
 import { MensagemComponent } from '../../../ui/mensagem/mensagem.component';
 import { SidebarFuncionarioComponent } from '../../../ui/sidebar-funcionario/sidebar-funcionario.component';
 
 @Component({
 	selector: 'app-pagina-relatorio-receitas',
 	standalone: true,
-	imports: [CommonModule, FormsModule, RouterOutlet, SidebarFuncionarioComponent, MensagemComponent],
+        imports: [CommonModule, FormsModule, RouterOutlet, SidebarFuncionarioComponent, MensagemComponent, MultiSelectEstadoComponent],
 	templateUrl: './pagina-relatorio-receitas.component.html',
 	styleUrls: ['./pagina-relatorio-receitas.component.css'],
 })
 export class PaginaRelatorioReceitasComponent {
-	dataInicio?: string;
-	dataFim?: string;
-	resultados: ReceitaPorDia[] = [];
+        dataInicio?: string;
+        dataFim?: string;
+        estadosSelecionados: Situacao[] = [Situacao.FINALIZADA];
+        resultados: ReceitaPorDia[] = [];
 	mensagem = '';
 	showMessage = false;
 
 	constructor(private reportService: ReportService) {}
 
-	buscar(): void {
-		const inicio = this.dataInicio ? new Date(this.dataInicio) : undefined;
-		const fim = this.dataFim ? new Date(this.dataFim) : undefined;
-		this.reportService.getReceitaPorDia(inicio, fim).subscribe((resultados) => {
-			this.resultados = resultados;
-		});
-	}
+        buscar(): void {
+                const inicio = this.dataInicio ? new Date(this.dataInicio) : undefined;
+                const fim = this.dataFim ? new Date(this.dataFim) : undefined;
+                this.reportService
+                        .getReceitaPorDia(inicio, fim, this.estadosSelecionados)
+                        .subscribe((resultados) => {
+                                this.resultados = resultados;
+                        });
+        }
 
 	gerarPDF(): void {
 		if (!this.resultados.length) {

--- a/frontend/src/app/components/ui/multi-select-estado/multi-select-estado.component.html
+++ b/frontend/src/app/components/ui/multi-select-estado/multi-select-estado.component.html
@@ -1,0 +1,8 @@
+<mat-form-field appearance="fill" class="w-56">
+  <mat-label>Situações</mat-label>
+  <mat-select [(ngModel)]="selecionados" multiple (selectionChange)="onSelectionChange()">
+    <mat-option *ngFor="let estado of estados" [value]="estado">
+      {{ estado }}
+    </mat-option>
+  </mat-select>
+</mat-form-field>

--- a/frontend/src/app/components/ui/multi-select-estado/multi-select-estado.component.spec.ts
+++ b/frontend/src/app/components/ui/multi-select-estado/multi-select-estado.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MultiSelectEstadoComponent } from './multi-select-estado.component';
+import { Situacao } from '../../../shared/models/solicitacao.model';
+
+describe('MultiSelectEstadoComponent', () => {
+  let component: MultiSelectEstadoComponent;
+  let fixture: ComponentFixture<MultiSelectEstadoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MultiSelectEstadoComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MultiSelectEstadoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit estados when selection changes', () => {
+    const estados = [Situacao.ABERTA, Situacao.PAGA];
+    spyOn(component.estadosChange, 'emit');
+    component.selecionados = estados;
+    component.onSelectionChange();
+    expect(component.estadosChange.emit).toHaveBeenCalledWith(estados);
+  });
+});

--- a/frontend/src/app/components/ui/multi-select-estado/multi-select-estado.component.ts
+++ b/frontend/src/app/components/ui/multi-select-estado/multi-select-estado.component.ts
@@ -1,0 +1,24 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+
+import { Situacao } from '../../../shared/models/solicitacao.model';
+
+@Component({
+    selector: 'app-multi-select-estado',
+    standalone: true,
+    imports: [CommonModule, FormsModule, MatFormFieldModule, MatSelectModule],
+    templateUrl: './multi-select-estado.component.html',
+})
+export class MultiSelectEstadoComponent {
+    @Output() estadosChange = new EventEmitter<Situacao[]>();
+
+    estados = Object.values(Situacao);
+    selecionados: Situacao[] = [Situacao.FINALIZADA];
+
+    onSelectionChange() {
+        this.estadosChange.emit(this.selecionados);
+    }
+}

--- a/frontend/src/app/services/report.service.spec.ts
+++ b/frontend/src/app/services/report.service.spec.ts
@@ -1,0 +1,89 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+
+import { ReportService } from './report.service';
+import { SolicitacaoService } from './solicitacao.service';
+import { Situacao, Solicitacao } from '../shared/models/solicitacao.model';
+import { Categoria } from '../shared/models/categoria.model';
+import { Pessoa } from '../shared/models/pessoa.model';
+
+describe('ReportService', () => {
+  let service: ReportService;
+  let solicitacaoServiceSpy: jasmine.SpyObj<SolicitacaoService>;
+
+  beforeEach(() => {
+    solicitacaoServiceSpy = jasmine.createSpyObj('SolicitacaoService', ['listarSolicitacoes']);
+    TestBed.configureTestingModule({
+      providers: [
+        ReportService,
+        { provide: SolicitacaoService, useValue: solicitacaoServiceSpy }
+      ]
+    });
+    service = TestBed.inject(ReportService);
+  });
+
+  it('should filter solicitacoes by situacao for categoria', (done) => {
+    const solicitacoes: Solicitacao[] = [
+      {
+        id: 1,
+        descricao: '',
+        categoria: { id: 1, descricao: 'A' } as Categoria,
+        defeito: '',
+        situacao: Situacao.FINALIZADA,
+        cliente: {} as Pessoa,
+        orcamento: 100,
+        dataSolicitacaoAbertura: new Date('2024-01-01'),
+      } as Solicitacao,
+      {
+        id: 2,
+        descricao: '',
+        categoria: { id: 1, descricao: 'A' } as Categoria,
+        defeito: '',
+        situacao: Situacao.PAGA,
+        cliente: {} as Pessoa,
+        orcamento: 50,
+        dataSolicitacaoAbertura: new Date('2024-01-01'),
+      } as Solicitacao,
+    ];
+    solicitacaoServiceSpy.listarSolicitacoes.and.returnValue(of(solicitacoes));
+
+    service.getReceitaPorCategoria([Situacao.FINALIZADA]).subscribe((res) => {
+      expect(res.length).toBe(1);
+      expect(res[0].total).toBe(100);
+      done();
+    });
+  });
+
+  it('should filter solicitacoes by situacao for dia', (done) => {
+    const data = new Date('2024-01-01');
+    const solicitacoes: Solicitacao[] = [
+      {
+        id: 1,
+        descricao: '',
+        categoria: { id: 1, descricao: 'A' } as Categoria,
+        defeito: '',
+        situacao: Situacao.FINALIZADA,
+        cliente: {} as Pessoa,
+        orcamento: 100,
+        dataSolicitacaoAbertura: data,
+      } as Solicitacao,
+      {
+        id: 2,
+        descricao: '',
+        categoria: { id: 2, descricao: 'B' } as Categoria,
+        defeito: '',
+        situacao: Situacao.PAGA,
+        cliente: {} as Pessoa,
+        orcamento: 50,
+        dataSolicitacaoAbertura: data,
+      } as Solicitacao,
+    ];
+    solicitacaoServiceSpy.listarSolicitacoes.and.returnValue(of(solicitacoes));
+
+    service.getReceitaPorDia(undefined, undefined, [Situacao.PAGA]).subscribe((res) => {
+      expect(res.length).toBe(1);
+      expect(res[0].total).toBe(50);
+      done();
+    });
+  });
+});

--- a/frontend/src/app/services/report.service.ts
+++ b/frontend/src/app/services/report.service.ts
@@ -19,13 +19,17 @@ export interface ReceitaPorCategoria {
 export class ReportService {
 	constructor(private solicitacaoService: SolicitacaoService) {}
 
-	getReceitaPorDia(dataInicio?: Date, dataFim?: Date): Observable<ReceitaPorDia[]> {
+        getReceitaPorDia(
+                dataInicio?: Date,
+                dataFim?: Date,
+                estados: Situacao[] = [Situacao.FINALIZADA]
+        ): Observable<ReceitaPorDia[]> {
 		/* O codigo de antes nao funcionava em um contexto assincrono, entao eu alterei. Faz a mesma coisa, mas funciona com o padrao Observable */
 		return this.solicitacaoService.listarSolicitacoes().pipe(
 			map((solicitacoes) => {
-				const solicitacoesPagas = solicitacoes.filter((s) => s.situacao === Situacao.FINALIZADA);
+                                const solicitacoesPorEstado = solicitacoes.filter((s) => estados.includes(s.situacao));
 
-				const solicitacoesFiltradas = solicitacoesPagas.filter((s) => {
+                                const solicitacoesFiltradas = solicitacoesPorEstado.filter((s) => {
 					const dataDaSolicitacao = s.dataFinalizacao
 						? new Date(s.dataFinalizacao)
 						: s.dataSolicitacaoAbertura
@@ -62,14 +66,14 @@ export class ReportService {
 		);
 	}
 
-	getReceitaPorCategoria(): Observable<ReceitaPorCategoria[]> {
+        getReceitaPorCategoria(estados: Situacao[] = [Situacao.FINALIZADA]): Observable<ReceitaPorCategoria[]> {
 		/* Mesma coisa pra esse codigo. */
 		return this.solicitacaoService.listarSolicitacoes().pipe(
 			map((solicitacoes: Solicitacao[]) => {
-				const solicitacoesPagas = solicitacoes.filter((s) => s.situacao === Situacao.FINALIZADA);
+                                const solicitacoesFiltradas = solicitacoes.filter((s) => estados.includes(s.situacao));
 
 				const mapa = new Map<string, number>();
-				solicitacoesPagas.forEach((s) => {
+                                solicitacoesFiltradas.forEach((s) => {
 					const nomeCategoria = s.categoria.descricao;
 					const orcamento = s.orcamento ?? 0;
 					mapa.set(nomeCategoria, (mapa.get(nomeCategoria) || 0) + orcamento);


### PR DESCRIPTION
## Summary
- criar componente `multi-select-estado` com `mat-select multiple`
- permitir que métodos do `ReportService` filtrem por múltiplas situações
- atualizar páginas de relatório para usar o novo componente e passar os estados selecionados
- acrescentar testes de serviço e do componente
