### PR TITLE
Replace Material in multi-select

### DIFF
--- a/frontend/src/app/components/ui/multi-select-estado/multi-select-estado.component.html
+++ b/frontend/src/app/components/ui/multi-select-estado/multi-select-estado.component.html
@@ -1,8 +1,16 @@
-<mat-form-field appearance="fill" class="w-56">
-  <mat-label>Situações</mat-label>
-  <mat-select [(ngModel)]="selecionados" multiple (selectionChange)="onSelectionChange()">
-    <mat-option *ngFor="let estado of estados" [value]="estado">
+<label
+        for="estados"
+        class="px-2.5 py-[6px] rounded-md rounded-r-none text-sm text-gray-900/60 font-medium bg-gray-900/15 outline-1 outline-gray-900/30"
+        >Situações</label>
+<select
+        id="estados"
+        name="estados"
+        multiple
+        class="focus:outline-primary focus:outline-2 outline-1 outline-gray-900/15 px-2.5 py-[5px] text-sm rounded-md rounded-l-none w-fit"
+        [(ngModel)]="selecionados"
+        (change)="onSelectionChange()"
+>
+    <option *ngFor="let estado of estados" [ngValue]="estado">
       {{ estado }}
-    </mat-option>
-  </mat-select>
-</mat-form-field>
+    </option>
+</select>

--- a/frontend/src/app/components/ui/multi-select-estado/multi-select-estado.component.spec.ts
+++ b/frontend/src/app/components/ui/multi-select-estado/multi-select-estado.component.spec.ts
@@ -24,7 +24,9 @@ describe('MultiSelectEstadoComponent', () => {
     const estados = [Situacao.ABERTA, Situacao.PAGA];
     spyOn(component.estadosChange, 'emit');
     component.selecionados = estados;
-    component.onSelectionChange();
+    fixture.detectChanges();
+    const select: HTMLSelectElement = fixture.nativeElement.querySelector('select');
+    select.dispatchEvent(new Event('change'));
     expect(component.estadosChange.emit).toHaveBeenCalledWith(estados);
   });
 });

--- a/frontend/src/app/components/ui/multi-select-estado/multi-select-estado.component.ts
+++ b/frontend/src/app/components/ui/multi-select-estado/multi-select-estado.component.ts
@@ -1,15 +1,13 @@
 import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectModule } from '@angular/material/select';
 
 import { Situacao } from '../../../shared/models/solicitacao.model';
 
 @Component({
     selector: 'app-multi-select-estado',
     standalone: true,
-    imports: [CommonModule, FormsModule, MatFormFieldModule, MatSelectModule],
+    imports: [CommonModule, FormsModule],
     templateUrl: './multi-select-estado.component.html',
 })
 export class MultiSelectEstadoComponent {


### PR DESCRIPTION
## Summary
- swap Angular Material with native select for multi-select-estado
- update standalone component imports
- adjust tests for select change handling

## Testing
- `npm test` *(fails: ng not found)*
- `npx ng test --watch=false` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*
- `npx ng build` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_e_685cb9e0eaac83258b506f78a644bb80